### PR TITLE
Expose raw readings in Measurement struct, allow passing compensation functions.

### DIFF
--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -76,6 +76,6 @@ defmodule SHT4X do
   @impl GenServer
   def handle_call({:measure, opts}, _from, state) do
     {:ok, data} = SHT4X.Comm.measure(state.transport, opts)
-    {:reply, {:ok, SHT4X.Measurement.from_raw(data)}, state}
+    {:reply, {:ok, SHT4X.Measurement.from_raw(data, opts)}, state}
   end
 end

--- a/lib/sht4x/measurement.ex
+++ b/lib/sht4x/measurement.ex
@@ -9,14 +9,26 @@ defmodule SHT4X.Measurement do
     field(:dew_point_c, number)
     field(:humidity_rh, number, enforce: true)
     field(:temperature_c, number, enforce: true)
+    field(:raw_reading_temperature, integer, enforce: true)
+    field(:raw_reading_humidity, integer, enforce: true)
     field(:timestamp_ms, integer, enforce: true)
   end
 
-  @spec from_raw(<<_::48>>) :: t()
-  def from_raw(<<raw_t::16, _crc1, raw_rh::16, _crc2>>) do
+  @spec from_raw(<<_::48>>, Keyword.t()) :: t()
+  def from_raw(<<raw_t::16, _crc1, raw_rh::16, _crc2>>, opts) do
+    temperature_compensation_func =
+      Keyword.get(opts, :temperature_compensation_func, fn v -> v end)
+
+    humidity_compensation_func = Keyword.get(opts, :humidity_compensation_func, fn v -> v end)
+
+    corrected_raw_t = temperature_compensation_func.(raw_t)
+    corrected_raw_rh = humidity_compensation_func.(raw_rh)
+
     __struct__(
-      humidity_rh: humidity_rh_from_raw(raw_rh),
-      temperature_c: temperature_c_from_raw(raw_t),
+      humidity_rh: humidity_rh_from_raw(corrected_raw_rh),
+      temperature_c: temperature_c_from_raw(corrected_raw_t),
+      raw_reading_temperature: raw_t,
+      raw_reading_humidity: raw_rh,
       timestamp_ms: System.monotonic_time(:millisecond)
     )
     |> put_dew_point_c()


### PR DESCRIPTION
When calling `SHT4X.measure` you can pass in 2 new options: `:temperature_compensation_func` and `humidity_compensation_func` which are 1 arity anonymous functions where the first argument is the raw reading from the sensor, and expected return value is a single corrected integer. 

This is useful for correcting the values from the sensor BEFORE they are converted into human readable C/Relative Humidity values. If left `nil` these functions are identity functions, and do not modify the value.

This PR also adds 2 new fields to the `Measurement` struct: `:raw_reading_temperature` and `raw_reading_humidity` which are the raw values from the sensor, they are *NOT* run through the compensation functions.